### PR TITLE
Failing test for fragments with array fields bug

### DIFF
--- a/test/anywhere.ts
+++ b/test/anywhere.ts
@@ -361,6 +361,61 @@ describe('graphql anywhere', () => {
     });
   });
 
+  it('can resolve fragments with array fields', () => {
+    const resolver = (fieldName, root) => {
+      return root[fieldName];
+    };
+
+    const query = gql`
+      {
+        ...on Droid {
+          episodes {
+            name
+          }
+        }
+        ...on Human {
+          episodes {
+            name
+            year
+            ship {
+              name
+            }
+          }
+        }
+      }
+    `;
+
+    const result: any = {
+      id: 'human@123',
+      episodes: [
+        {
+          id: 'episode@123',
+          name: 'Rogue One',
+          year: 2016,
+          ship: {
+            id: 'ship@123',
+            name: 'U-Wing',
+          },
+        },
+      ],
+    };
+
+    const queryResult = graphql(resolver, query, result);
+
+    // no "id" fields
+    assert.deepEqual(queryResult, {
+      episodes: [
+        {
+          name: 'Rogue One',
+          year: 2016,
+          ship: {
+            name: 'U-Wing',
+          },
+        },
+      ],
+    });
+  });
+
   it('readme example', () => {
     // I don't need all this stuff!
     const gitHubAPIResponse = {


### PR DESCRIPTION
This PR provides the failing test for a scenario when `graphql-everywhere` is trying to resolve the fragments with a field of the Array type (also described [here](https://github.com/apollostack/react-apollo/issues/386)).

I found out that the root cause is [this line](https://github.com/apollostack/graphql-anywhere/blob/master/src/index.ts#L254) in the `merge` function implementation, but I am not sure about the desired behavior of `merge`. Whether we want to do a classic "deep" merge here or we want to have some "special" behavior.

 @stubailo I would be happy to contribute a fix for this, but I need an input regarding the abovementioned questions.