### PR TITLE
Deep merge arrays when merging fragment results

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -243,8 +243,7 @@ function merge(dest, src) {
     typeof src === 'undefined' ||
     typeof src === 'string' ||
     typeof src === 'number' ||
-    typeof src === 'boolean' ||
-    Array.isArray(src)
+    typeof src === 'boolean'
   ) {
     // These types just override whatever was in dest
     return src;

--- a/test/anywhere.ts
+++ b/test/anywhere.ts
@@ -394,6 +394,46 @@ describe('graphql anywhere', () => {
     });
   });
 
+  it('can resolve deeply nested fragments with arrays', () => {
+    const resolver = (fieldName, root) => {
+      return root[fieldName];
+    };
+
+    const query = gql`
+      {
+        ...on Item {
+          array { id field1 }
+        }
+        ...on Item {
+          array { id field2 }
+        }
+        ...on Item {
+          array { id field3 }
+        }
+      }
+    `;
+
+    const result: any = {
+      array: [{
+        id: 'abcde',
+        field1: 1,
+        field2: 2,
+        field3: 3,
+      }],
+    };
+
+    const queryResult = graphql(resolver, query, result);
+
+    assert.deepEqual(queryResult, {
+      array: [{
+        id: 'abcde',
+        field1: 1,
+        field2: 2,
+        field3: 3,
+      }],
+    });
+  });
+
   it('readme example', () => {
     // I don't need all this stuff!
     const gitHubAPIResponse = {


### PR DESCRIPTION
When merging arrays resulting from multiple fragments, only results from last
fragment were used, ignoring selectionsets from preceding fragments.

This commit changes behaviour of merge so that arrays are also deep-merged.

Related to #28, #29, https://github.com/apollostack/apollo-client/issues/1231