### PR TITLE
Handle mutation queries.

### DIFF
--- a/src/getFromAST.ts
+++ b/src/getFromAST.ts
@@ -133,11 +133,15 @@ export function getMainDefinition(queryDoc: DocumentNode): OperationDefinitionNo
     return getQueryDefinition(queryDoc);
   } catch (e) {
     try {
-      const fragments = getFragmentDefinitions(queryDoc);
-
-      return fragments[0];
+      return getMutationDefinition(queryDoc);
     } catch (e) {
-      throw new Error(`Expected a parsed GraphQL query with a query or a fragment.`);
+      try {
+        const fragments = getFragmentDefinitions(queryDoc);
+
+        return fragments[0];
+      } catch (e) {
+        throw new Error(`Expected a parsed GraphQL query with a query, mutation, or a fragment.`);
+      }
     }
   }
 }

--- a/test/anywhere.ts
+++ b/test/anywhere.ts
@@ -646,4 +646,48 @@ describe('graphql anywhere', () => {
       },
     });
   });
+
+  it('can handle mutations', () => {
+    const resolver = (fieldName, root, args) => {
+      if (fieldName === 'operateOnNumbers') {
+        return args;
+      } else if (fieldName === 'add') {
+        return root.a + root.b;
+      } else if (fieldName === 'subtract') {
+        return root.a - root.b;
+      } else if (fieldName === 'multiply') {
+        return root.a * root.b;
+      } else if (fieldName === 'divide') {
+        return root.a / root.b;
+      }
+    };
+
+    const query = gql`
+      mutation {
+        operateOnNumbers(a: 10, b: 2) {
+          add
+          subtract
+          multiply
+          divide
+        }
+      }
+    `;
+
+    const result = graphql(
+      resolver,
+      query,
+      '',
+      null,
+      null
+    );
+
+    assert.deepEqual(result, {
+      operateOnNumbers: {
+        add: 12,
+        subtract: 8,
+        multiply: 20,
+        divide: 5,
+      },
+    });
+  });
 });


### PR DESCRIPTION
This change includes a test.

Previously, `graphql-anywhere` would fail on mutation queries:
```graphql
mutation {
  operateOnNumbers(a: 10, b: 2) {
    add
    subtract
    multiply
    divide
  }
}
```

with the following error:
```
TypeError: Cannot read property 'selectionSet' of undefined
  at Object.graphql (graphql-anywhere/src/graphql.ts:98:19)
```

Now in `getMainDefinition`, if `getQueryDefinition` fails we also look for `getMutationDefinition`.