### PR TITLE
Filter utility now works with include/skip directives

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -85,7 +85,7 @@ export function graphql(
 
   // Default matcher always matches all fragments
   const fragmentMatcher = execOptions.fragmentMatcher || (() => true);
-  const ignoreIncludeDirectives = execOptions.ignoreIncludeDirectives;
+  const ignoreIncludeDirectives = !!execOptions.ignoreIncludeDirectives;
 
   const execContext: ExecContext = {
     fragmentMap,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -44,6 +44,7 @@ export type ExecContext = {
   resultMapper: ResultMapper;
   resolver: Resolver;
   fragmentMatcher: FragmentMatcher;
+  ignoreIncludeDirectives: boolean;
 }
 
 
@@ -55,6 +56,7 @@ export type ExecInfo = {
 export type ExecOptions = {
   resultMapper?: ResultMapper;
   fragmentMatcher?: FragmentMatcher;
+  ignoreIncludeDirectives?: boolean;
 }
 
 // Based on graphql function from graphql-js:
@@ -83,6 +85,7 @@ export function graphql(
 
   // Default matcher always matches all fragments
   const fragmentMatcher = execOptions.fragmentMatcher || (() => true);
+  const ignoreIncludeDirectives = execOptions.ignoreIncludeDirectives;
 
   const execContext: ExecContext = {
     fragmentMap,
@@ -91,6 +94,7 @@ export function graphql(
     resultMapper,
     resolver,
     fragmentMatcher,
+    ignoreIncludeDirectives,
   };
 
   return executeSelectionSet(
@@ -110,12 +114,13 @@ function executeSelectionSet(
     fragmentMap,
     contextValue,
     variableValues: variables,
+    ignoreIncludeDirectives,
   } = execContext;
 
   const result = {};
 
   selectionSet.selections.forEach((selection) => {
-    if (! shouldInclude(selection, variables)) {
+    if (!ignoreIncludeDirectives && !shouldInclude(selection, variables)) {
       // Skip this entirely
       return;
     }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -15,7 +15,7 @@ export function filter(doc: DocumentNode, data: any): any {
     return root[info.resultKey];
   };
 
-  return graphql(resolver, doc, data);
+  return graphql(resolver, doc, data, null, null, {ignoreIncludeDirectives: true});
 }
 
 // TODO: we should probably make check call propType and then throw,

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -62,6 +62,41 @@ describe('utilities', () => {
     });
   });
 
+  describe('with query with directives', () => {
+    const queryWithDirectives = gql`
+      query withDirectives($withAvatar: Boolean!) {
+        alias: name
+        height(unit: METERS)
+        avatar @include(if: $withAvatar) {
+          square
+        }
+      }
+    `;
+
+    const data = {
+      alias: 'Bob',
+      name: 'Wrong',
+      height: 1.89,
+      avatar: {
+        square: 'abc',
+        circle: 'def',
+      },
+    };
+    const filteredData = {
+      alias: 'Bob',
+      height: 1.89,
+      avatar: {
+        square: 'abc',
+      },
+    };
+
+
+    it('can filter data', () => {
+      assert.deepEqual(filter(queryWithDirectives, data), filteredData);
+    });
+
+  });
+
   describe('with a single fragment', () => {
     const doc = gql`
       fragment PersonDetails on Person {


### PR DESCRIPTION
Filter utility used to fail when given query with directives, because variables were not provided. Now it ignores include/skip directives and can handle such queries.
See https://github.com/apollographql/graphql-anywhere/issues/38