### PR TITLE
Improving AST util performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,12 @@
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^3.4.34",
-    "@types/isomorphic-fetch": "0.0.31",
+    "@types/graphql": "^0.8.0",
     "@types/lodash": "^4.14.37",
     "@types/mocha": "^2.2.32",
     "@types/node": "^6.0.46",
     "@types/react": "^0.14.43",
     "@types/react-dom": "^0.14.18",
-    "@types/graphql": "^0.8.0",
     "async": "^2.0.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
@@ -55,6 +54,6 @@
     "remap-istanbul": "^0.5.1",
     "source-map-support": "^0.4.0",
     "tslint": "3.15.1",
-    "typescript": "^2.0.0"
+    "typescript": "^2.2.1"
   }
 }

--- a/test/anywhere.ts
+++ b/test/anywhere.ts
@@ -730,4 +730,40 @@ describe('graphql anywhere', () => {
       },
     });
   });
+
+  it('can handle subscriptions', () => {
+    const data = {
+      user: {
+        id: 1,
+        name: 'Some User',
+        height: 1.89,
+      },
+    };
+
+    const resolver = (fieldName, root) => root[fieldName];
+
+    const query = gql`
+      subscription {
+        user {
+          id
+          name
+          height
+        }
+      }
+    `;
+
+    const result = graphql(
+      resolver,
+      query,
+      data
+    );
+
+    assert.deepEqual(result, {
+      user: {
+        id: 1,
+        name: 'Some User',
+        height: 1.89,
+      },
+    });
+  });
 });


### PR DESCRIPTION
I noticed that the `getMainDefinition` had a lot of try / catch (which de-opts code), and also a ton of code duplication. I rolled all of the child functions into a single function, which also allows us to avoid having to try/catch anything.

While I was here, I added support for querying subscriptions. 

@helfer for visibility.